### PR TITLE
Add a check in ouichefs_unlink to avoid freeing of block 0

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -365,6 +365,9 @@ static int ouichefs_unlink(struct inode *dir, struct dentry *dentry)
 	for (i = 0; i < inode->i_blocks - 1; i++) {
 		char *block;
 
+		if(!file_block->blocks[i])
+			continue;
+
 		put_block(sbi, file_block->blocks[i]);
 		bh2 = sb_bread(sb, file_block->blocks[i]);
 		if (!bh2)


### PR DESCRIPTION
This PR fix #6 . 
It adds a check in the function ouichefs_unlink to avoid a call to put_block if index[i] points to block 0.
