### PR TITLE
mkfs: Fix incorrect comparison for minimum fs size

### DIFF
--- a/mkfs/mkfs-ouichefs.c
+++ b/mkfs/mkfs-ouichefs.c
@@ -335,7 +335,7 @@ int main(int argc, char **argv)
 
 	/* Check if image is large enough */
 	min_size = 100 * OUICHEFS_BLOCK_SIZE;
-	if (stat_buf.st_size <= min_size) {
+	if (stat_buf.st_size < min_size) {
 		fprintf(stderr,
 			"File is not large enough (size=%ld, min size=%ld)\n",
 			stat_buf.st_size, min_size);


### PR DESCRIPTION
When calling mkfs on a file or device that has just the minimum size of 100 blocks or 4 KiB, then mkfs fails with this great error message:

	File is not large enough (size=409600, min size=409600)

We have provided a patch that fixes the comparison so that creating a file system with its minimum size is supported by mkfs.