### PR TITLE
Don't perform mkfs on an argument that starts with a dash

### DIFF
--- a/mkfs/mkfs-ouichefs.c
+++ b/mkfs/mkfs-ouichefs.c
@@ -313,7 +313,7 @@ int main(int argc, char **argv)
 	struct stat stat_buf;
 	struct ouichefs_superblock *sb = NULL;
 
-	if (argc != 2) {
+	if (argc != 2 || argv[1][0] == '-') {
 		usage(argv[0]);
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
When we first used mkfs, we assumed that it wants the device as a parameter, but were not sure if it wanted other parameters or options so we called it with `--help` first. This results in the following output:

	open():: No such file or directory

This is not exactly the help message we expected. Therefore, we have provided a patch that makes mkfs print a help message whenever the argument starts with a dash. This will cover all cases where the user asked for a help message, as well as in all other cases where the user provided options that did not exist.