### PR TITLE
Fix calculation of filecount in statfs

### DIFF
--- a/super.c
+++ b/super.c
@@ -212,7 +212,7 @@ static int ouichefs_statfs(struct dentry *dentry, struct kstatfs *stat)
 	stat->f_blocks = sbi->nr_blocks;
 	stat->f_bfree = sbi->nr_free_blocks;
 	stat->f_bavail = sbi->nr_free_blocks;
-	stat->f_files = sbi->nr_inodes - sbi->nr_free_inodes;
+	stat->f_files = sbi->nr_inodes;
 	stat->f_ffree = sbi->nr_free_inodes;
 	stat->f_namelen = OUICHEFS_FILENAME_LEN;
 


### PR DESCRIPTION
The current implementation wrongly sets the f_files member to the number of used inodes. However, f_files is supposed to be set to the maximum number of files the filesystem supports.[1]

This leads to some bizarre output in programs that utilize statfs() like df, which prints negative values of "inodes used".