### PR TITLE
Fix missing dot links in root directory

### DIFF
--- a/mkfs/mkfs-ouichefs.c
+++ b/mkfs/mkfs-ouichefs.c
@@ -146,8 +146,8 @@ static int write_inode_store(int fd, struct ouichefs_superblock *sb)
 		return -1;
 	memset(block, 0, OUICHEFS_BLOCK_SIZE);
 
-	/* Root inode (inode 0) */
-	inode = (struct ouichefs_inode *)block;
+	/* Root inode (inode 1) */
+	inode = (struct ouichefs_inode *)block + 1;
 	first_data_block = 1 + le32toh(sb->nr_bfree_blocks) +
 			   le32toh(sb->nr_ifree_blocks) +
 			   le32toh(sb->nr_istore_blocks);
@@ -204,7 +204,7 @@ static int write_ifree_blocks(int fd, struct ouichefs_superblock *sb)
 	memset(ifree, 0xff, OUICHEFS_BLOCK_SIZE);
 
 	/* First ifree block, containing first used inode */
-	ifree[0] = htole64(0xfffffffffffffffe);
+	ifree[0] = htole64(0xfffffffffffffffc);
 	ret = write(fd, ifree, OUICHEFS_BLOCK_SIZE);
 	if (ret != OUICHEFS_BLOCK_SIZE) {
 		ret = -1;

--- a/super.c
+++ b/super.c
@@ -318,7 +318,7 @@ int ouichefs_fill_super(struct super_block *sb, void *data, int silent)
 	}
 
 	/* Create root inode */
-	root_inode = ouichefs_iget(sb, 0);
+	root_inode = ouichefs_iget(sb, 1);
 	if (IS_ERR(root_inode)) {
 		ret = PTR_ERR(root_inode);
 		goto free_bfree;


### PR DESCRIPTION
This one probably jumps straight in the eye of everyone who uses an alias for ls that displays hidden files.

ouichefs uses inode no. 0 as the root inode which is not forbidden by the kernel but shunned in practice. The kernel does not expect 0 [1] and the glibc implementation of readdir() only fixed this in 2022 for 2.37 [2]. While the commit message acknowledges that inode no. 0 is not in itself faulty, I would suggest merging this fix to stay compatible with current userspace applications.


[1] https://elixir.bootlin.com/linux/v6.5.7/source/fs/inode.c#L996
[2] https://sourceware.org/git/?p=glibc.git;a=commit;h=766b73768b290b303f5b56268c6c0d588d5a9267