### PR TITLE
Reset flags when reassigning inode

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -198,6 +198,7 @@ static struct inode *ouichefs_new_inode(struct inode *dir, mode_t mode)
 		set_nlink(inode, 1);
 	}
 
+	inode->i_flags = 0;
 	inode->i_ctime = inode->i_atime = inode->i_mtime = current_time(inode);
 
 	return inode;


### PR DESCRIPTION
Re-creating a removed directory will render it unusable if the assigned inode was flagged as dead upon removal. The bug can be reproduced via
```bash
cd $MOUNTDIR
mkdir 1
rmdir 1
mkdir 2
cd 2
touch b
```
causing file b to not be created. Resetting the flag resolves this problem.