### PR TITLE
fix: issue with round up of i_blocks number

### DIFF
--- a/file.c
+++ b/file.c
@@ -146,7 +146,9 @@ static int ouichefs_write_end(struct file *file, struct address_space *mapping,
 		uint32_t nr_blocks_old = inode->i_blocks;
 
 		/* Update inode metadata */
-		inode->i_blocks = inode->i_size / OUICHEFS_BLOCK_SIZE + 2;
+		inode->i_blocks = (inode->i_size / OUICHEFS_BLOCK_SIZE) + 1;
+		if ((inode->i_size % OUICHEFS_BLOCK_SIZE) != 0)
+			inode->i_blocks++;
 		inode->i_mtime = inode->i_ctime = current_time(inode);
 		mark_inode_dirty(inode);
 


### PR DESCRIPTION
When we tried to read every blocks of a complete file (4MiB), `inode->i_blocks` returned 1026, when the max blocks count should be 1025 (including index block).  Thus we provide a patch that round up precisely `i_blocks` in `ouichefs_write_end`.