### PR TITLE
Fix: inode->i_blocks value on open in truncate mode

### DIFF
--- a/file.c
+++ b/file.c
@@ -214,7 +214,7 @@ static int ouichefs_open(struct inode *inode, struct file *file) {
 			index->blocks[iblock] = 0;
 		}
 		inode->i_size = 0;
-		inode->i_blocks = 0;
+		inode->i_blocks = 1;
 
 		brelse(bh_index);
 	}


### PR DESCRIPTION
inode->i_blocks should have a value of 1 when file is truncated to account for the index block