### PR TITLE
mkfs: Remove : from perror macros

### DIFF
--- a/mkfs/mkfs-ouichefs.c
+++ b/mkfs/mkfs-ouichefs.c
@@ -349,14 +349,14 @@ int main(int argc, char **argv)
 	/* Open disk image */
 	fd = open(argv[1], O_RDWR);
 	if (fd == -1) {
-		perror("open():");
+		perror("open()");
 		return EXIT_FAILURE;
 	}
 
 	/* Get image size */
 	ret = fstat(fd, &stat_buf);
 	if (ret != 0) {
-		perror("fstat():");
+		perror("fstat()");
 		ret = EXIT_FAILURE;
 		goto fclose;
 	}
@@ -374,7 +374,7 @@ int main(int argc, char **argv)
 	/* Write superblock (block 0) */
 	sb = write_superblock(fd, &stat_buf);
 	if (!sb) {
-		perror("write_superblock():");
+		perror("write_superblock()");
 		ret = EXIT_FAILURE;
 		goto fclose;
 	}
@@ -382,7 +382,7 @@ int main(int argc, char **argv)
 	/* Write inode store blocks (from block 1) */
 	ret = write_inode_store(fd, sb);
 	if (ret != 0) {
-		perror("write_inode_store():");
+		perror("write_inode_store()");
 		ret = EXIT_FAILURE;
 		goto free_sb;
 	}
@@ -414,7 +414,7 @@ int main(int argc, char **argv)
 	/* Write data blocks */
 	ret = write_data_blocks(fd, sb);
 	if (ret != 0) {
-		perror("write_data_blocks():");
+		perror("write_data_blocks()");
 		ret = EXIT_FAILURE;
 		goto free_sb;
 	}


### PR DESCRIPTION
According to the manual of perror(3):
"The argument string s is printed, followed by a colon and a blank."

As such, the colon in mkfs-ouichefs.c is unnecessary.

See: https://man7.org/linux/man-pages/man3/perror.3.html