### PR TITLE
fix formatting, code-correctness and marking a buffer dirty when contents has been modified

### DIFF
--- a/file.c
+++ b/file.c
@@ -56,6 +56,7 @@ static int ouichefs_file_get_block(struct inode *inode, sector_t iblock,
 			goto brelse_index;
 		}
 		index->blocks[iblock] = bno;
+		mark_buffer_dirty(bh_index);
 	} else {
 		bno = index->blocks[iblock];
 	}

--- a/file.c
+++ b/file.c
@@ -192,7 +192,8 @@ const struct address_space_operations ouichefs_aops = {
 	.write_end = ouichefs_write_end
 };
 
-static int ouichefs_open(struct inode *inode, struct file *file) {
+static int ouichefs_open(struct inode *inode, struct file *file)
+{
 	bool wronly = (file->f_flags & O_WRONLY) != 0;
 	bool rdwr = (file->f_flags & O_RDWR) != 0;
 	bool trunc = (file->f_flags & O_TRUNC) != 0;
@@ -220,7 +221,7 @@ static int ouichefs_open(struct inode *inode, struct file *file) {
 
 		brelse(bh_index);
 	}
-	
+
 	return 0;
 }
 

--- a/inode.c
+++ b/inode.c
@@ -392,8 +392,8 @@ clean_inode:
 	inode->i_mode = 0;
 	inode->i_ctime.tv_sec = inode->i_mtime.tv_sec = inode->i_atime.tv_sec =
 		0;
-	inode->i_ctime.tv_nsec = inode->i_mtime.tv_nsec = inode->i_atime.tv_nsec =
-		0;
+	inode->i_ctime.tv_nsec = inode->i_mtime.tv_nsec =
+		inode->i_atime.tv_nsec = 0;
 	inode_dec_link_count(inode);
 	mark_inode_dirty(inode);
 

--- a/inode.c
+++ b/inode.c
@@ -366,14 +366,15 @@ static int ouichefs_unlink(struct inode *dir, struct dentry *dentry)
 		if (!file_block->blocks[i])
 			continue;
 
-		put_block(sbi, file_block->blocks[i]);
 		bh2 = sb_bread(sb, file_block->blocks[i]);
 		if (!bh2)
-			continue;
+			goto put_block;
 		block = (char *)bh2->b_data;
 		memset(block, 0, OUICHEFS_BLOCK_SIZE);
 		mark_buffer_dirty(bh2);
 		brelse(bh2);
+put_block:
+		put_block(sbi, file_block->blocks[i]);
 	}
 
 scrub:


### PR DESCRIPTION
This PR contributes three commits.
1. applies correct clang-format at two places
2. Fixes a rather inconvenient bug which makes your files loose its contents if you're unlucky
3. code correctness about writing to an block marked as unused

See the commit messages for more details.