### PR TITLE
prevent deferred index block write back from destroying file data

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -380,6 +380,7 @@ scrub:
 	/* Scrub index block */
 	memset(file_block, 0, OUICHEFS_BLOCK_SIZE);
 	mark_buffer_dirty(bh);
+	sync_dirty_buffer(bh);
 	brelse(bh);
 
 clean_inode:


### PR DESCRIPTION
File write operations and write operation on index blocks (sb_bread) use independent pagecaches for caching the disk contents. A dirty block that was used as an index_block and is freed in the block bitmap, but not synced back immediately will cause a race condition between both cache writebacks.

If the file writeback occurs before the index_block writeback, the files data is overwritten.

Force the scrub to sync immediatly so that a deferred writeback won't occur.

A simple reproducer is this command sequence in a shell, preferably in a single commandline to trigger the race condition.

```sh
# create a new empty file to preallocate its index block
touch file

# create a new dir to use the next available block as an index block
mkdir dir

# unlink the directory to scrub its index block without immediate sync
rmdir dir

# reuse the scrubbed block as a file block
echo data > file

# sync and drop caches to ensure index_block writeback
sync -f file
echo 3 > /proc/sys/vm/drop_caches

# file is sometimes empty
cat file
```