### PR TITLE
don't update atime where not required

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -131,10 +131,6 @@ static struct dentry *ouichefs_lookup(struct inode *dir, struct dentry *dentry,
 	}
 	brelse(bh);
 
-	/* Update directory access time */
-	dir->i_atime = current_time(dir);
-	mark_inode_dirty(dir);
-
 	/* Fill the dentry with the inode */
 	d_add(dentry, inode);
 
@@ -279,7 +275,7 @@ static int ouichefs_create(struct mnt_idmap *idmap, struct inode *dir,
 
 	/* Update stats and mark dir and new inode dirty */
 	mark_inode_dirty(inode);
-	dir->i_mtime = dir->i_atime = dir->i_ctime = current_time(dir);
+	dir->i_mtime = dir->i_ctime = current_time(dir);
 	if (S_ISDIR(mode))
 		inode_inc_link_count(dir);
 	mark_inode_dirty(dir);
@@ -343,7 +339,7 @@ static int ouichefs_unlink(struct inode *dir, struct dentry *dentry)
 	brelse(bh);
 
 	/* Update inode stats */
-	dir->i_mtime = dir->i_atime = dir->i_ctime = current_time(dir);
+	dir->i_mtime = dir->i_ctime = current_time(dir);
 	if (S_ISDIR(inode->i_mode))
 		inode_dec_link_count(dir);
 	mark_inode_dirty(dir);
@@ -392,8 +388,8 @@ clean_inode:
 	inode->i_mode = 0;
 	inode->i_ctime.tv_sec = inode->i_mtime.tv_sec = inode->i_atime.tv_sec =
 		0;
-	inode->i_ctime.tv_nsec = inode->i_mtime.tv_nsec = inode->i_atime.tv_nsec =
-		0;
+	inode->i_ctime.tv_nsec = inode->i_mtime.tv_nsec =
+		inode->i_atime.tv_nsec = 0;
 	inode_dec_link_count(inode);
 	mark_inode_dirty(inode);
 
@@ -498,8 +494,7 @@ static int ouichefs_rename(struct mnt_idmap *idmap, struct inode *old_dir,
 	brelse(bh_old);
 
 	/* Update old parent inode metadata */
-	old_dir->i_atime = old_dir->i_ctime = old_dir->i_mtime =
-		current_time(old_dir);
+	old_dir->i_ctime = old_dir->i_mtime = current_time(old_dir);
 	if (S_ISDIR(src->i_mode))
 		inode_dec_link_count(old_dir);
 	mark_inode_dirty(old_dir);


### PR DESCRIPTION
The linux VFS mandates that a vfs lookup in a directory does not update atimes.

> Passing through a directory to access a file within is not considered to
> be an access for the purposes of `atime`; only listing the contents of a
> directory can update its `atime`.

The POSIX specification section 4.9 dictates how timestamps on UNIX-like systems should be handled.

> Each function or utility in POSIX.1-2017 that reads or writes data (even
> if the data does not change) or performs an operation to change file status
> (even if the file status does not change) indicates which of the appropriate
> timestamps shall be marked for update.

See  https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html#tag_04_09

A `rename`, `unlink` or `create` should not update the parent directories' atimes, only mtime and ctime.

> Upon successful completion, rename() shall mark for update the last data
> modification and last file status change timestamps of the parent directory
> of each file.

See https://pubs.opengroup.org/onlinepubs/9699919799/functions/rename.html

> Upon successful completion, unlink() shall mark for update the last
> data modification and last file status change timestamps of the parent
> directory. Also, if the file's link count is not 0, the last file status
> change timestamp of the file shall be marked for update.

See https://pubs.opengroup.org/onlinepubs/9699919799/functions/unlink.html

> If O_CREAT is set and the file did not previously exist, upon successful
> completion, open() shall mark for update the last data access, last data
> modification, and last file status change timestamps of the file and the
> last data modification and last file status change timestamps of the parent
> directory.

See https://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html