### PR TITLE
 Fix: Mark buffer as dirty after allocating new block in ouichefs_file_get_block 

### DIFF
--- a/file.c
+++ b/file.c
@@ -56,6 +56,7 @@ static int ouichefs_file_get_block(struct inode *inode, sector_t iblock,
 			goto brelse_index;
 		}
 		index->blocks[iblock] = bno;
+		mark_buffer_dirty(bh_index);
 	} else {
 		bno = index->blocks[iblock];
 	}
@@ -220,7 +221,7 @@ static int ouichefs_open(struct inode *inode, struct file *file) {
 
 		brelse(bh_index);
 	}
-	
+
 	return 0;
 }
 


### PR DESCRIPTION
This commit addresses an issue in the `ouichefs_file_get_block` function where the buffer head was not marked as dirty after allocating a new block. This lead to inconsistencies in the filesystem as the changes were not being properly written to disk.