### PR TITLE
Add missing endianness conversions

### DIFF
--- a/bitmap.h
+++ b/bitmap.h
@@ -104,4 +104,35 @@ static inline void put_block(struct ouichefs_sb_info *sbi, uint32_t bno)
 	pr_debug("%s:%d: freed block %u\n", __func__, __LINE__, bno);
 }
 
+static inline void copy_bitmap_from_le64(unsigned long *dst, __le64 *src)
+{
+	int i;
+
+	for (i = 0; i < (OUICHEFS_BLOCK_SIZE >> 3); i++) {
+#if BITS_PER_LONG == 64
+		dst[i] = le64_to_cpu(src[i]);
+#elif BITS_PER_LONG == 32
+		dst[(i << 1) + 0] = le64_to_cpu(src[i]) >> 0;
+		dst[(i << 1) + 1] = le64_to_cpu(src[i]) >> 32;
+#else
+#error Unsupported long size.
+#endif
+	}
+}
+
+static inline void copy_bitmap_to_le64(__le64 *dst, unsigned long *src)
+{
+	int i;
+
+	for (i = 0; i < (OUICHEFS_BLOCK_SIZE >> 3); i++) {
+#if BITS_PER_LONG == 64
+		dst[i] = cpu_to_le64(src[i]);
+#elif BITS_PER_LONG == 32
+		dst[i] = cpu_to_le64(((uint64_t)src[(i << 1) + 1] << 32) | src[i << 1]);
+#else
+#error Unsupported long size.
+#endif
+	}
+}
+
 #endif /* _OUICHEFS_BITMAP_H */

--- a/dir.c
+++ b/dir.c
@@ -54,8 +54,8 @@ static int ouichefs_iterate(struct file *dir, struct dir_context *ctx)
 		f = &dblock->files[i];
 		if (!f->inode)
 			break;
-		if (!dir_emit(ctx, f->filename, OUICHEFS_FILENAME_LEN, f->inode,
-			      DT_UNKNOWN))
+		if (!dir_emit(ctx, f->filename, OUICHEFS_FILENAME_LEN,
+				le32_to_cpu(f->inode), DT_UNKNOWN))
 			break;
 		ctx->pos++;
 	}

--- a/file.c
+++ b/file.c
@@ -55,9 +55,9 @@ static int ouichefs_file_get_block(struct inode *inode, sector_t iblock,
 			ret = -ENOSPC;
 			goto brelse_index;
 		}
-		index->blocks[iblock] = bno;
+		index->blocks[iblock] = cpu_to_le32(bno);
 	} else {
-		bno = index->blocks[iblock];
+		bno = le32_to_cpu(index->blocks[iblock]);
 	}
 
 	/* Map the physical block to the given buffer_head */
@@ -174,7 +174,7 @@ static int ouichefs_write_end(struct file *file, struct address_space *mapping,
 
 			for (i = inode->i_blocks - 1; i < nr_blocks_old - 1;
 			     i++) {
-				put_block(OUICHEFS_SB(sb), index->blocks[i]);
+				put_block(OUICHEFS_SB(sb), le32_to_cpu(index->blocks[i]));
 				index->blocks[i] = 0;
 			}
 			mark_buffer_dirty(bh_index);
@@ -212,7 +212,7 @@ static int ouichefs_open(struct inode *inode, struct file *file) {
 		index = (struct ouichefs_file_index_block *)bh_index->b_data;
 
 		for (iblock = 0; index->blocks[iblock] != 0; iblock++) {
-			put_block(sbi, index->blocks[iblock]);
+			put_block(sbi, le32_to_cpu(index->blocks[iblock]));
 			index->blocks[iblock] = 0;
 		}
 		inode->i_size = 0;

--- a/mkfs/mkfs-ouichefs.c
+++ b/mkfs/mkfs-ouichefs.c
@@ -128,9 +128,11 @@ static struct ouichefs_superblock *write_superblock(int fd, struct stat *fstats)
 	       "\tnr_bfree_blocks=%u\n"
 	       "\tnr_free_inodes=%u\n"
 	       "\tnr_free_blocks=%u\n",
-	       sizeof(struct ouichefs_superblock), sb->magic, sb->nr_blocks,
-	       sb->nr_inodes, sb->nr_istore_blocks, sb->nr_ifree_blocks,
-	       sb->nr_bfree_blocks, sb->nr_free_inodes, sb->nr_free_blocks);
+	       sizeof(struct ouichefs_superblock), le32toh(sb->magic),
+		   le32toh(sb->nr_blocks), le32toh(sb->nr_inodes),
+		   le32toh(sb->nr_istore_blocks),
+		   le32toh(sb->nr_ifree_blocks), le32toh(sb->nr_bfree_blocks),
+		   le32toh(sb->nr_free_inodes), le32toh(sb->nr_free_blocks));
 
 	return sb;
 }
@@ -174,7 +176,7 @@ static int write_inode_store(int fd, struct ouichefs_superblock *sb)
 
 	/* Reset inode store blocks to zero */
 	memset(block, 0, OUICHEFS_BLOCK_SIZE);
-	for (i = 1; i < sb->nr_istore_blocks; i++) {
+	for (i = 1; i < le32toh(sb->nr_istore_blocks); i++) {
 		ret = write(fd, block, OUICHEFS_BLOCK_SIZE);
 		if (ret != OUICHEFS_BLOCK_SIZE) {
 			ret = -1;

--- a/ouichefs.h
+++ b/ouichefs.h
@@ -37,19 +37,19 @@
  */
 
 struct ouichefs_inode {
-	uint32_t i_mode; /* File mode */
-	uint32_t i_uid; /* Owner id */
-	uint32_t i_gid; /* Group id */
-	uint32_t i_size; /* Size in bytes */
-	uint32_t i_ctime; /* Inode change time (sec)*/
-	uint64_t i_nctime; /* Inode change time (nsec) */
-	uint32_t i_atime; /* Access time (sec) */
-	uint64_t i_natime; /* Access time (nsec) */
-	uint32_t i_mtime; /* Modification time (sec) */
-	uint64_t i_nmtime; /* Modification time (nsec) */
-	uint32_t i_blocks; /* Block count */
-	uint32_t i_nlink; /* Hard links count */
-	uint32_t index_block; /* Block with list of blocks for this file */
+	__le32 i_mode; /* File mode */
+	__le32 i_uid; /* Owner id */
+	__le32 i_gid; /* Group id */
+	__le32 i_size; /* Size in bytes */
+	__le32 i_ctime; /* Inode change time (sec)*/
+	__le64 i_nctime; /* Inode change time (nsec) */
+	__le32 i_atime; /* Access time (sec) */
+	__le64 i_natime; /* Access time (nsec) */
+	__le32 i_mtime; /* Modification time (sec) */
+	__le64 i_nmtime; /* Modification time (nsec) */
+	__le32 i_blocks; /* Block count */
+	__le32 i_nlink; /* Hard links count */
+	__le32 index_block; /* Block with list of blocks for this file */
 };
 
 struct ouichefs_inode_info {
@@ -78,12 +78,12 @@ struct ouichefs_sb_info {
 };
 
 struct ouichefs_file_index_block {
-	uint32_t blocks[OUICHEFS_BLOCK_SIZE >> 2];
+	__le32 blocks[OUICHEFS_BLOCK_SIZE >> 2];
 };
 
 struct ouichefs_dir_block {
 	struct ouichefs_file {
-		uint32_t inode;
+		__le32 inode;
 		char filename[OUICHEFS_FILENAME_LEN];
 	} files[OUICHEFS_MAX_SUBFILES];
 };


### PR DESCRIPTION
Add missing endianness conversions throughout the file system implementation, which should make it possible to use the file system on systems with big endian as well.

For the `ifree` and `bfree` bitmaps, the conversions are slightly more complex, because we must consider that the data type used for bitmaps in Linux (unsigned long) could be only 32 bits large on some architectures.

Also use `__le32` and `__le64` instead of `uint32_t` and `uint64_t` in `ouichefs_inode`, `ouichefs_file_index_block` and `ouichefs_file` structs. This makes it apparent to programmers that these fields are always in little endian due to directly corresponding to data on the block device.