### PR TITLE
fix: Ensure correct endianness

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -54,8 +54,8 @@ static int ouichefs_iterate(struct file *dir, struct dir_context *ctx)
 		f = &dblock->files[i];
 		if (!f->inode)
 			break;
-		if (!dir_emit(ctx, f->filename, OUICHEFS_FILENAME_LEN, f->inode,
-			      DT_UNKNOWN))
+		if (!dir_emit(ctx, f->filename, OUICHEFS_FILENAME_LEN,
+			      le32_to_cpu(f->inode), DT_UNKNOWN))
 			break;
 		ctx->pos++;
 	}

--- a/file.c
+++ b/file.c
@@ -55,9 +55,9 @@ static int ouichefs_file_get_block(struct inode *inode, sector_t iblock,
 			ret = -ENOSPC;
 			goto brelse_index;
 		}
-		index->blocks[iblock] = bno;
+		index->blocks[iblock] = cpu_to_le32(bno);
 	} else {
-		bno = index->blocks[iblock];
+		bno = le32_to_cpu(index->blocks[iblock]);
 	}
 
 	/* Map the physical block to the given buffer_head */
@@ -192,7 +192,8 @@ const struct address_space_operations ouichefs_aops = {
 	.write_end = ouichefs_write_end
 };
 
-static int ouichefs_open(struct inode *inode, struct file *file) {
+static int ouichefs_open(struct inode *inode, struct file *file)
+{
 	bool wronly = (file->f_flags & O_WRONLY) != 0;
 	bool rdwr = (file->f_flags & O_RDWR) != 0;
 	bool trunc = (file->f_flags & O_TRUNC) != 0;
@@ -220,7 +221,7 @@ static int ouichefs_open(struct inode *inode, struct file *file) {
 
 		brelse(bh_index);
 	}
-	
+
 	return 0;
 }
 

--- a/inode.c
+++ b/inode.c
@@ -125,7 +125,7 @@ static struct dentry *ouichefs_lookup(struct inode *dir, struct dentry *dentry,
 			break;
 		if (!strncmp(f->filename, dentry->d_name.name,
 			     OUICHEFS_FILENAME_LEN)) {
-			inode = ouichefs_iget(sb, f->inode);
+			inode = ouichefs_iget(sb, le32_to_cpu(f->inode));
 			break;
 		}
 	}
@@ -271,7 +271,7 @@ static int ouichefs_create(struct mnt_idmap *idmap, struct inode *dir,
 	for (i = 0; i < OUICHEFS_MAX_SUBFILES; i++)
 		if (dblock->files[i].inode == 0)
 			break;
-	dblock->files[i].inode = inode->i_ino;
+	dblock->files[i].inode = cpu_to_le32(inode->i_ino);
 	strscpy(dblock->files[i].filename, dentry->d_name.name,
 		OUICHEFS_FILENAME_LEN);
 	mark_buffer_dirty(bh);
@@ -327,7 +327,7 @@ static int ouichefs_unlink(struct inode *dir, struct dentry *dentry)
 
 	/* Search for inode in parent index and get number of subfiles */
 	for (i = 0; i < OUICHEFS_MAX_SUBFILES; i++) {
-		if (dir_block->files[i].inode == ino)
+		if (le32_to_cpu(dir_block->files[i].inode) == ino)
 			f_id = i;
 		else if (dir_block->files[i].inode == 0)
 			break;
@@ -462,7 +462,7 @@ static int ouichefs_rename(struct mnt_idmap *idmap, struct inode *old_dir,
 	}
 
 	/* insert in new parent directory */
-	dir_block->files[new_pos].inode = src->i_ino;
+	dir_block->files[new_pos].inode = cpu_to_le32(src->i_ino);
 	strscpy(dir_block->files[new_pos].filename, new_dentry->d_name.name,
 		OUICHEFS_FILENAME_LEN);
 	mark_buffer_dirty(bh_new);
@@ -482,7 +482,7 @@ static int ouichefs_rename(struct mnt_idmap *idmap, struct inode *old_dir,
 	dir_block = (struct ouichefs_dir_block *)bh_old->b_data;
 	/* Search for inode in old directory and number of subfiles */
 	for (i = 0; OUICHEFS_MAX_SUBFILES; i++) {
-		if (dir_block->files[i].inode == src->i_ino)
+		if (le32_to_cpu(dir_block->files[i].inode) == src->i_ino)
 			f_id = i;
 		else if (dir_block->files[i].inode == 0)
 			break;

--- a/mkfs/Makefile
+++ b/mkfs/Makefile
@@ -1,11 +1,20 @@
 BIN ?= mkfs.ouichefs
 IMG ?= test.img
 IMGSIZE ?= 50
+CC ?= gcc
+CFLAGS ?= -Wall
+
+prefix ?= /usr/local
+exec_prefix ?= $(prefix)
+bindir ?= $(exec_prefix)/bin
 
 all: ${BIN}
 
 ${BIN}: mkfs-ouichefs.c
-	gcc -Wall -o $@ $<
+	${CC} ${CFLAGS} ${LDFLAGS} -o $@ $<
+
+install: ${BIN}
+	install -Dm 755 ${BIN} $(DESTDIR)$(bindir)/mkfs.ouichefs
 
 img: ${BIN}
 	rm -rf ${IMG}
@@ -19,4 +28,4 @@ clean:
 mrproper: clean
 	rm -rf ${BIN}
 
-.PHONY: all clean mrproper img
+.PHONY: all install clean mrproper img

--- a/mkfs/mkfs-ouichefs.c
+++ b/mkfs/mkfs-ouichefs.c
@@ -128,9 +128,9 @@ static struct ouichefs_superblock *write_superblock(int fd, struct stat *fstats)
 	       "\tnr_bfree_blocks=%u\n"
 	       "\tnr_free_inodes=%u\n"
 	       "\tnr_free_blocks=%u\n",
-	       sizeof(struct ouichefs_superblock), sb->magic, sb->nr_blocks,
-	       sb->nr_inodes, sb->nr_istore_blocks, sb->nr_ifree_blocks,
-	       sb->nr_bfree_blocks, sb->nr_free_inodes, sb->nr_free_blocks);
+	       sizeof(struct ouichefs_superblock), OUICHEFS_MAGIC, nr_blocks,
+	       nr_inodes, nr_istore_blocks, nr_ifree_blocks, nr_bfree_blocks,
+	       nr_inodes - 1, nr_data_blocks - 1);
 
 	return sb;
 }
@@ -174,7 +174,7 @@ static int write_inode_store(int fd, struct ouichefs_superblock *sb)
 
 	/* Reset inode store blocks to zero */
 	memset(block, 0, OUICHEFS_BLOCK_SIZE);
-	for (i = 1; i < sb->nr_istore_blocks; i++) {
+	for (i = 1; i < le32toh(sb->nr_istore_blocks); i++) {
 		ret = write(fd, block, OUICHEFS_BLOCK_SIZE);
 		if (ret != OUICHEFS_BLOCK_SIZE) {
 			ret = -1;

--- a/super.c
+++ b/super.c
@@ -12,6 +12,7 @@
 #include <linux/buffer_head.h>
 #include <linux/slab.h>
 #include <linux/statfs.h>
+#include <linux/byteorder/generic.h>
 
 #include "ouichefs.h"
 
@@ -74,19 +75,19 @@ static int ouichefs_write_inode(struct inode *inode,
 	disk_inode += inode_shift;
 
 	/* update the mode using what the generic inode has */
-	disk_inode->i_mode = inode->i_mode;
-	disk_inode->i_uid = i_uid_read(inode);
-	disk_inode->i_gid = i_gid_read(inode);
-	disk_inode->i_size = inode->i_size;
-	disk_inode->i_ctime = inode->i_ctime.tv_sec;
-	disk_inode->i_nctime = inode->i_ctime.tv_nsec;
-	disk_inode->i_atime = inode->i_atime.tv_sec;
-	disk_inode->i_natime = inode->i_atime.tv_nsec;
-	disk_inode->i_mtime = inode->i_mtime.tv_sec;
-	disk_inode->i_nmtime = inode->i_mtime.tv_nsec;
-	disk_inode->i_blocks = inode->i_blocks;
-	disk_inode->i_nlink = inode->i_nlink;
-	disk_inode->index_block = ci->index_block;
+	disk_inode->i_mode = cpu_to_le32(inode->i_mode);
+	disk_inode->i_uid = cpu_to_le32(i_uid_read(inode));
+	disk_inode->i_gid = cpu_to_le32(i_gid_read(inode));
+	disk_inode->i_size = cpu_to_le32(inode->i_size);
+	disk_inode->i_ctime = cpu_to_le32(inode->i_ctime.tv_sec);
+	disk_inode->i_nctime = cpu_to_le64(inode->i_ctime.tv_nsec);
+	disk_inode->i_atime = cpu_to_le32(inode->i_atime.tv_sec);
+	disk_inode->i_natime = cpu_to_le64(inode->i_atime.tv_nsec);
+	disk_inode->i_mtime = cpu_to_le32(inode->i_mtime.tv_sec);
+	disk_inode->i_nmtime = cpu_to_le64(inode->i_mtime.tv_nsec);
+	disk_inode->i_blocks = cpu_to_le32(inode->i_blocks);
+	disk_inode->i_nlink = cpu_to_le32(inode->i_nlink);
+	disk_inode->index_block = cpu_to_le32(ci->index_block);
 
 	mark_buffer_dirty(bh);
 	sync_dirty_buffer(bh);
@@ -107,13 +108,13 @@ static int sync_sb_info(struct super_block *sb, int wait)
 		return -EIO;
 	disk_sb = (struct ouichefs_sb_info *)bh->b_data;
 
-	disk_sb->nr_blocks = sbi->nr_blocks;
-	disk_sb->nr_inodes = sbi->nr_inodes;
-	disk_sb->nr_istore_blocks = sbi->nr_istore_blocks;
-	disk_sb->nr_ifree_blocks = sbi->nr_ifree_blocks;
-	disk_sb->nr_bfree_blocks = sbi->nr_bfree_blocks;
-	disk_sb->nr_free_inodes = sbi->nr_free_inodes;
-	disk_sb->nr_free_blocks = sbi->nr_free_blocks;
+	disk_sb->nr_blocks = cpu_to_le32(sbi->nr_blocks);
+	disk_sb->nr_inodes = cpu_to_le32(sbi->nr_inodes);
+	disk_sb->nr_istore_blocks = cpu_to_le32(sbi->nr_istore_blocks);
+	disk_sb->nr_ifree_blocks = cpu_to_le32(sbi->nr_ifree_blocks);
+	disk_sb->nr_bfree_blocks = cpu_to_le32(sbi->nr_bfree_blocks);
+	disk_sb->nr_free_inodes = cpu_to_le32(sbi->nr_free_inodes);
+	disk_sb->nr_free_blocks = cpu_to_le32(sbi->nr_free_blocks);
 
 	mark_buffer_dirty(bh);
 	if (wait)
@@ -137,9 +138,13 @@ static int sync_ifree(struct super_block *sb, int wait)
 		if (!bh)
 			return -EIO;
 
-		memcpy(bh->b_data,
-		       (void *)sbi->ifree_bitmap + i * OUICHEFS_BLOCK_SIZE,
-		       OUICHEFS_BLOCK_SIZE);
+		unsigned long *src =
+			sbi->ifree_bitmap + i * OUICHEFS_BLOCK_SIZE;
+		unsigned long *dst = (unsigned long *)bh->b_data;
+
+		for (int j = 0; j < OUICHEFS_BLOCK_SIZE / sizeof(unsigned long);
+		     j++)
+			dst[j] = cpu_to_le64(src[j]);
 
 		mark_buffer_dirty(bh);
 		if (wait)
@@ -164,9 +169,13 @@ static int sync_bfree(struct super_block *sb, int wait)
 		if (!bh)
 			return -EIO;
 
-		memcpy(bh->b_data,
-		       (void *)sbi->bfree_bitmap + i * OUICHEFS_BLOCK_SIZE,
-		       OUICHEFS_BLOCK_SIZE);
+		unsigned long *src =
+			sbi->bfree_bitmap + i * OUICHEFS_BLOCK_SIZE;
+		unsigned long *dst = (unsigned long *)bh->b_data;
+
+		for (int j = 0; j < OUICHEFS_BLOCK_SIZE / sizeof(unsigned long);
+		     j++)
+			dst[j] = cpu_to_le64(src[j]);
 
 		mark_buffer_dirty(bh);
 		if (wait)
@@ -254,7 +263,7 @@ int ouichefs_fill_super(struct super_block *sb, void *data, int silent)
 	csb = (struct ouichefs_sb_info *)bh->b_data;
 
 	/* Check magic number */
-	if (csb->magic != sb->s_magic) {
+	if (le32_to_cpu(csb->magic) != sb->s_magic) {
 		pr_err("Wrong magic number\n");
 		ret = -EPERM;
 		goto release;
@@ -266,13 +275,13 @@ int ouichefs_fill_super(struct super_block *sb, void *data, int silent)
 		ret = -ENOMEM;
 		goto release;
 	}
-	sbi->nr_blocks = csb->nr_blocks;
-	sbi->nr_inodes = csb->nr_inodes;
-	sbi->nr_istore_blocks = csb->nr_istore_blocks;
-	sbi->nr_ifree_blocks = csb->nr_ifree_blocks;
-	sbi->nr_bfree_blocks = csb->nr_bfree_blocks;
-	sbi->nr_free_inodes = csb->nr_free_inodes;
-	sbi->nr_free_blocks = csb->nr_free_blocks;
+	sbi->nr_blocks = le32_to_cpu(csb->nr_blocks);
+	sbi->nr_inodes = le32_to_cpu(csb->nr_inodes);
+	sbi->nr_istore_blocks = le32_to_cpu(csb->nr_istore_blocks);
+	sbi->nr_ifree_blocks = le32_to_cpu(csb->nr_ifree_blocks);
+	sbi->nr_bfree_blocks = le32_to_cpu(csb->nr_bfree_blocks);
+	sbi->nr_free_inodes = le32_to_cpu(csb->nr_free_inodes);
+	sbi->nr_free_blocks = le32_to_cpu(csb->nr_free_blocks);
 	sb->s_fs_info = sbi;
 
 	brelse(bh);
@@ -293,8 +302,13 @@ int ouichefs_fill_super(struct super_block *sb, void *data, int silent)
 			goto free_ifree;
 		}
 
-		memcpy((void *)sbi->ifree_bitmap + i * OUICHEFS_BLOCK_SIZE,
-		       bh->b_data, OUICHEFS_BLOCK_SIZE);
+		unsigned long *src = (unsigned long *)bh->b_data;
+		unsigned long *dst =
+			sbi->ifree_bitmap + i * OUICHEFS_BLOCK_SIZE;
+
+		for (int j = 0; j < OUICHEFS_BLOCK_SIZE / sizeof(unsigned long);
+		     j++)
+			dst[j] = cpu_to_le64(src[j]);
 
 		brelse(bh);
 	}
@@ -315,8 +329,13 @@ int ouichefs_fill_super(struct super_block *sb, void *data, int silent)
 			goto free_bfree;
 		}
 
-		memcpy((void *)sbi->bfree_bitmap + i * OUICHEFS_BLOCK_SIZE,
-		       bh->b_data, OUICHEFS_BLOCK_SIZE);
+		unsigned long *src = (unsigned long *)bh->b_data;
+		unsigned long *dst =
+			sbi->bfree_bitmap + i * OUICHEFS_BLOCK_SIZE;
+
+		for (int j = 0; j < OUICHEFS_BLOCK_SIZE / sizeof(unsigned long);
+		     j++)
+			dst[j] = cpu_to_le64(src[j]);
 
 		brelse(bh);
 	}


### PR DESCRIPTION
ouiche_fs does not take host endianness into account.
This makes ouichefs practically unusable on (exotic but important!) big endian architectures.

This PR fixes that by introducing the necessary conversions for (meta) data written/read to/from disk, which are always in little endian.
Little and big endian host architectures should be able to safely exchange data with each other using ouiche_fs.

This was tested for aarch64 big-endian architectures (using QEMU's virt platform).