### PR TITLE
Use locking for bitmaps to avoid race conditions

### DIFF
--- a/bitmap.h
+++ b/bitmap.h
@@ -8,6 +8,7 @@
 #define _OUICHEFS_BITMAP_H
 
 #include <linux/bitmap.h>
+#include <linux/mutex.h>
 #include "ouichefs.h"
 
 /*
@@ -39,12 +40,17 @@ static inline uint32_t get_free_inode(struct ouichefs_sb_info *sbi)
 {
 	uint32_t ret;
 
+	mutex_lock(&sbi->ifree_lock);
+
 	ret = get_first_free_bit(sbi->ifree_bitmap, sbi->nr_inodes);
 	if (ret) {
 		sbi->nr_free_inodes--;
 		pr_debug("%s:%d: allocated inode %u\n", __func__, __LINE__,
 			 ret);
 	}
+
+	mutex_unlock(&sbi->ifree_lock);
+
 	return ret;
 }
 
@@ -56,12 +62,17 @@ static inline uint32_t get_free_block(struct ouichefs_sb_info *sbi)
 {
 	uint32_t ret;
 
+	mutex_lock(&sbi->bfree_lock);
+
 	ret = get_first_free_bit(sbi->bfree_bitmap, sbi->nr_blocks);
 	if (ret) {
 		sbi->nr_free_blocks--;
 		pr_debug("%s:%d: allocated block %u\n", __func__, __LINE__,
 			 ret);
 	}
+
+	mutex_unlock(&sbi->bfree_lock);
+
 	return ret;
 }
 
@@ -85,11 +96,16 @@ static inline int put_free_bit(unsigned long *freemap, unsigned long size,
  */
 static inline void put_inode(struct ouichefs_sb_info *sbi, uint32_t ino)
 {
+	mutex_lock(&sbi->ifree_lock);
+
 	if (put_free_bit(sbi->ifree_bitmap, sbi->nr_inodes, ino))
-		return;
+		goto out_unlock;
 
 	sbi->nr_free_inodes++;
 	pr_debug("%s:%d: freed inode %u\n", __func__, __LINE__, ino);
+
+out_unlock:
+	mutex_unlock(&sbi->ifree_lock);
 }
 
 /*
@@ -97,11 +113,16 @@ static inline void put_inode(struct ouichefs_sb_info *sbi, uint32_t ino)
  */
 static inline void put_block(struct ouichefs_sb_info *sbi, uint32_t bno)
 {
+	mutex_lock(&sbi->bfree_lock);
+
 	if (put_free_bit(sbi->bfree_bitmap, sbi->nr_blocks, bno))
-		return;
+		goto out_unlock;
 
 	sbi->nr_free_blocks++;
 	pr_debug("%s:%d: freed block %u\n", __func__, __LINE__, bno);
+
+out_unlock:
+	mutex_unlock(&sbi->bfree_lock);
 }
 
 #endif /* _OUICHEFS_BITMAP_H */

--- a/ouichefs.h
+++ b/ouichefs.h
@@ -8,6 +8,7 @@
 #define _OUICHEFS_H
 
 #include <linux/fs.h>
+#include <linux/mutex.h>
 
 #define OUICHEFS_MAGIC 0x48434957
 
@@ -73,7 +74,9 @@ struct ouichefs_sb_info {
 	uint32_t nr_free_inodes; /* Number of free inodes */
 	uint32_t nr_free_blocks; /* Number of free blocks */
 
+	struct mutex ifree_lock;
 	unsigned long *ifree_bitmap; /* In-memory free inodes bitmap */
+	struct mutex bfree_lock;
 	unsigned long *bfree_bitmap; /* In-memory free blocks bitmap */
 };
 

--- a/super.c
+++ b/super.c
@@ -278,6 +278,7 @@ int ouichefs_fill_super(struct super_block *sb, void *data, int silent)
 	brelse(bh);
 
 	/* Alloc and copy ifree_bitmap */
+	mutex_init(&sbi->ifree_lock);
 	sbi->ifree_bitmap =
 		kzalloc(sbi->nr_ifree_blocks * OUICHEFS_BLOCK_SIZE, GFP_KERNEL);
 	if (!sbi->ifree_bitmap) {
@@ -300,6 +301,7 @@ int ouichefs_fill_super(struct super_block *sb, void *data, int silent)
 	}
 
 	/* Alloc and copy bfree_bitmap */
+	mutex_init(&sbi->bfree_lock);
 	sbi->bfree_bitmap =
 		kzalloc(sbi->nr_bfree_blocks * OUICHEFS_BLOCK_SIZE, GFP_KERNEL);
 	if (!sbi->bfree_bitmap) {


### PR DESCRIPTION
Prevent concurrent access to the ifree and bfree bitmaps by adding a file system wide mutex for each bitmap. Before, race conditions, which potentially corrupt the whole file system, could occur.