### PR TITLE
Defer inode deletion from unlinking to eviction

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -308,16 +308,13 @@ end:
 static int ouichefs_unlink(struct inode *dir, struct dentry *dentry)
 {
 	struct super_block *sb = dir->i_sb;
-	struct ouichefs_sb_info *sbi = OUICHEFS_SB(sb);
 	struct inode *inode = d_inode(dentry);
-	struct buffer_head *bh = NULL, *bh2 = NULL;
+	struct buffer_head *bh = NULL;
 	struct ouichefs_dir_block *dir_block = NULL;
-	struct ouichefs_file_index_block *file_block = NULL;
-	uint32_t ino, bno;
+	uint32_t ino;
 	int i, f_id = -1, nr_subs = 0;
 
 	ino = inode->i_ino;
-	bno = OUICHEFS_INODE(inode)->index_block;
 
 	/* Read parent directory index */
 	bh = sb_bread(sb, OUICHEFS_INODE(dir)->index_block);
@@ -342,64 +339,13 @@ static int ouichefs_unlink(struct inode *dir, struct dentry *dentry)
 	mark_buffer_dirty(bh);
 	brelse(bh);
 
+	inode_dec_link_count(inode);
+
 	/* Update inode stats */
 	dir->i_mtime = dir->i_atime = dir->i_ctime = current_time(dir);
 	if (S_ISDIR(inode->i_mode))
 		inode_dec_link_count(dir);
 	mark_inode_dirty(dir);
-
-	/*
-	 * Cleanup pointed blocks if unlinking a file. If we fail to read the
-	 * index block, cleanup inode anyway and lose this file's blocks
-	 * forever. If we fail to scrub a data block, don't fail (too late
-	 * anyway), just put the block and continue.
-	 */
-	bh = sb_bread(sb, bno);
-	if (!bh)
-		goto clean_inode;
-	file_block = (struct ouichefs_file_index_block *)bh->b_data;
-	if (S_ISDIR(inode->i_mode))
-		goto scrub;
-	for (i = 0; i < inode->i_blocks - 1; i++) {
-		char *block;
-
-		if (!file_block->blocks[i])
-			continue;
-
-		put_block(sbi, file_block->blocks[i]);
-		bh2 = sb_bread(sb, file_block->blocks[i]);
-		if (!bh2)
-			continue;
-		block = (char *)bh2->b_data;
-		memset(block, 0, OUICHEFS_BLOCK_SIZE);
-		mark_buffer_dirty(bh2);
-		brelse(bh2);
-	}
-
-scrub:
-	/* Scrub index block */
-	memset(file_block, 0, OUICHEFS_BLOCK_SIZE);
-	mark_buffer_dirty(bh);
-	brelse(bh);
-
-clean_inode:
-	/* Cleanup inode and mark dirty */
-	inode->i_blocks = 0;
-	OUICHEFS_INODE(inode)->index_block = 0;
-	inode->i_size = 0;
-	i_uid_write(inode, 0);
-	i_gid_write(inode, 0);
-	inode->i_mode = 0;
-	inode->i_ctime.tv_sec = inode->i_mtime.tv_sec = inode->i_atime.tv_sec =
-		0;
-	inode->i_ctime.tv_nsec = inode->i_mtime.tv_nsec = inode->i_atime.tv_nsec =
-		0;
-	inode_dec_link_count(inode);
-	mark_inode_dirty(inode);
-
-	/* Free inode and index block from bitmap */
-	put_block(sbi, bno);
-	put_inode(sbi, ino);
 
 	return 0;
 }
@@ -536,6 +482,8 @@ static int ouichefs_rmdir(struct inode *dir, struct dentry *dentry)
 		return -ENOTEMPTY;
 	}
 	brelse(bh);
+
+	inode_dec_link_count(inode);
 
 	/* Remove directory with unlink */
 	return ouichefs_unlink(dir, dentry);

--- a/super.c
+++ b/super.c
@@ -14,6 +14,7 @@
 #include <linux/statfs.h>
 
 #include "ouichefs.h"
+#include "bitmap.h"
 
 static struct kmem_cache *ouichefs_inode_cache;
 
@@ -93,6 +94,65 @@ static int ouichefs_write_inode(struct inode *inode,
 	brelse(bh);
 
 	return 0;
+}
+
+static void ouichefs_evict_inode(struct inode *inode)
+{
+	struct super_block *sb = inode->i_sb;
+	struct ouichefs_sb_info *sbi = OUICHEFS_SB(sb);
+	struct ouichefs_inode_info *inode_info = OUICHEFS_INODE(inode);
+	struct buffer_head *bh;
+	struct ouichefs_file_index_block *file_index;
+	uint32_t ino = inode->i_ino;
+	uint32_t i;
+
+	truncate_inode_pages_final(&inode->i_data);
+
+	/*
+	 * Cleanup pointed blocks if file/directory is not linked anymore.
+	 * If we fail to read the index block, cleanup inode anyway and
+	 * lose this file/directory's blocks forever.
+	 */
+	if (!inode->i_nlink && inode_info->index_block) {
+		bh = sb_bread(sb, inode_info->index_block);
+		if (!bh) {
+			pr_warn("failed to release index block\n");
+			goto invalidate;
+		}
+
+		if (S_ISREG(inode->i_mode)) {
+			file_index = (struct ouichefs_file_index_block *)bh->b_data;
+
+			for (i = 0; i < inode->i_blocks - 1; ++i) {
+				if (!le32_to_cpu(file_index->blocks[i]))
+					continue;
+
+				put_block(sbi, le32_to_cpu(file_index->blocks[i]));
+			}
+		}
+
+		/*
+		 * Make sure the buffer is not marked dirty anymore (and no writeback
+		 * is in progress), as we don't want it to be written back when it might
+		 * already be in use for something else (especially for the contents of a file)!
+		 */
+		lock_buffer(bh);
+		clear_buffer_dirty(bh);
+		unlock_buffer(bh);
+		brelse(bh);
+
+		put_block(sbi, inode_info->index_block);
+		inode_info->index_block = 0;
+	}
+
+invalidate:
+	invalidate_inode_buffers(inode);
+	clear_inode(inode);
+
+	if (!inode->i_nlink) {
+		/* Free inode from bitmap */
+		put_inode(sbi, ino);
+	}
 }
 
 static int sync_sb_info(struct super_block *sb, int wait)
@@ -227,6 +287,7 @@ static struct super_operations ouichefs_super_ops = {
 	.alloc_inode = ouichefs_alloc_inode,
 	.destroy_inode = ouichefs_destroy_inode,
 	.write_inode = ouichefs_write_inode,
+	.evict_inode = ouichefs_evict_inode,
 	.sync_fs = ouichefs_sync_fs,
 	.statfs = ouichefs_statfs,
 };


### PR DESCRIPTION
Inodes must not be deleted while there are still active references to it (for example trough open file descriptors), because in general, a file can be unlinked while it is still open, and this should not lead to data corruption. Instead, reads/writes with already open file descriptors should continue to work as normal.

Therefore, delete inodes from disks only when they are evicted in `ouichefs_evict_inode()`, and not already when they are unlinked. When unlinking an inode, only decrement link count.

We do not clear/scrub the individual fields of an inode anymore, because the inode will soon be freed from memory, and marking the inode dirty will probably not have an effect either. Also, when a new inode is allocated, fields will properly be initialized anyways.

This PR also fixes a race condition that could occur after a recently freed dirty index block is reused for the contents of a file. The unused but still dirty index block could possibly override file data when it is synced after the file. This is mitigated by clearing the dirty flag of the index block buffer head when it is freed.