### PR TITLE
Always initialize inode nlink to 1

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -190,13 +190,12 @@ static struct inode *ouichefs_new_inode(struct inode *dir, mode_t mode)
 	if (S_ISDIR(mode)) {
 		inode->i_size = OUICHEFS_BLOCK_SIZE;
 		inode->i_fop = &ouichefs_dir_ops;
-		set_nlink(inode, 2); /* . and .. */
 	} else if (S_ISREG(mode)) {
 		inode->i_size = 0;
 		inode->i_fop = &ouichefs_file_ops;
 		inode->i_mapping->a_ops = &ouichefs_aops;
-		set_nlink(inode, 1);
 	}
+	set_nlink(inode, 1);
 
 	inode->i_ctime = inode->i_atime = inode->i_mtime = current_time(inode);
 


### PR DESCRIPTION
`ouichefs_create:283` increments the link count for dirs. If this is done in both places, the link count will start at 3.

This will create a bug where removing a dir then immediately creating one, resulting in the new dir obtaining the same inode as the just removed dir, will cause the new dir to malfunction (unable to create files, `ls -la` doesn't show `.` and `..`) until remount.

minix fs increases the link count in `minix_mkdir` instead of `minix_new_inode` so I removed the duplicate increment from `ouichefs_new_inode` as well.