### PR TITLE
Properly support truncation

### DIFF
--- a/file.c
+++ b/file.c
@@ -50,12 +50,17 @@ static int ouichefs_file_get_block(struct inode *inode, sector_t iblock,
 			ret = 0;
 			goto brelse_index;
 		}
+
 		bno = get_free_block(sbi);
 		if (!bno) {
 			ret = -ENOSPC;
 			goto brelse_index;
 		}
+
 		index->blocks[iblock] = bno;
+		++inode->i_blocks;
+
+		mark_inode_dirty(inode);
 	} else {
 		bno = index->blocks[iblock];
 	}
@@ -97,29 +102,22 @@ static int ouichefs_write_begin(struct file *file,
 				unsigned int len, struct page **pagep,
 				void **fsdata)
 {
-	struct ouichefs_sb_info *sbi = OUICHEFS_SB(file->f_inode->i_sb);
 	int err;
-	uint32_t nr_allocs = 0;
-
-	/* Check if the write can be completed (enough space?) */
-	if (pos + len > OUICHEFS_MAX_FILESIZE)
-		return -ENOSPC;
-	nr_allocs = max(pos + len, file->f_inode->i_size) / OUICHEFS_BLOCK_SIZE;
-	if (nr_allocs > file->f_inode->i_blocks - 1)
-		nr_allocs -= file->f_inode->i_blocks - 1;
-	else
-		nr_allocs = 0;
-	if (nr_allocs > sbi->nr_free_blocks)
-		return -ENOSPC;
 
 	/* prepare the write */
 	err = block_write_begin(mapping, pos, len, pagep,
 				ouichefs_file_get_block);
 	/* if this failed, reclaim newly allocated blocks */
 	if (err < 0) {
-		pr_err("%s:%d: newly allocated blocks reclaim not implemented yet\n",
-		       __func__, __LINE__);
+		truncate_pagecache(file->f_inode, file->f_inode->i_size);
+		if (ouichefs_truncate(file->f_inode) < 0)
+			pr_err("%s:%d: truncate failed\n", __func__, __LINE__);
+		goto out;
 	}
+
+	return 0;
+
+out:
 	return err;
 }
 
@@ -134,8 +132,6 @@ static int ouichefs_write_end(struct file *file, struct address_space *mapping,
 {
 	int ret;
 	struct inode *inode = file->f_inode;
-	struct ouichefs_inode_info *ci = OUICHEFS_INODE(inode);
-	struct super_block *sb = inode->i_sb;
 
 	/* Complete the write() */
 	ret = generic_write_end(file, mapping, pos, len, copied, page, fsdata);
@@ -143,45 +139,11 @@ static int ouichefs_write_end(struct file *file, struct address_space *mapping,
 		pr_err("%s:%d: wrote less than asked... what do I do? nothing for now...\n",
 		       __func__, __LINE__);
 	} else {
-		uint32_t nr_blocks_old = inode->i_blocks;
-
 		/* Update inode metadata */
-		inode->i_blocks = (inode->i_size / OUICHEFS_BLOCK_SIZE) + 1;
-		if ((inode->i_size % OUICHEFS_BLOCK_SIZE) != 0)
-			inode->i_blocks++;
 		inode->i_mtime = inode->i_ctime = current_time(inode);
 		mark_inode_dirty(inode);
-
-		/* If file is smaller than before, free unused blocks */
-		if (nr_blocks_old > inode->i_blocks) {
-			int i;
-			struct buffer_head *bh_index;
-			struct ouichefs_file_index_block *index;
-
-			/* Free unused blocks from page cache */
-			truncate_pagecache(inode, inode->i_size);
-
-			/* Read index block to remove unused blocks */
-			bh_index = sb_bread(sb, ci->index_block);
-			if (!bh_index) {
-				pr_err("failed truncating '%s'. we just lost %llu blocks\n",
-				       file->f_path.dentry->d_name.name,
-				       nr_blocks_old - inode->i_blocks);
-				goto end;
-			}
-			index = (struct ouichefs_file_index_block *)
-					bh_index->b_data;
-
-			for (i = inode->i_blocks - 1; i < nr_blocks_old - 1;
-			     i++) {
-				put_block(OUICHEFS_SB(sb), index->blocks[i]);
-				index->blocks[i] = 0;
-			}
-			mark_buffer_dirty(bh_index);
-			brelse(bh_index);
-		}
 	}
-end:
+
 	return ret;
 }
 
@@ -231,3 +193,50 @@ const struct file_operations ouichefs_file_ops = {
 	.read_iter = generic_file_read_iter,
 	.write_iter = generic_file_write_iter
 };
+
+int ouichefs_truncate(struct inode *inode)
+{
+	int ret;
+	struct super_block *sb = inode->i_sb;
+	struct ouichefs_sb_info *sbi = OUICHEFS_SB(sb);
+	struct ouichefs_inode_info *inode_info = OUICHEFS_INODE(inode);
+	struct buffer_head *bh;
+	size_t next_num_blocks;
+
+	bh = sb_bread(sb, inode_info->index_block);
+	if (!bh) {
+		ret = -EIO;
+		goto out;
+	}
+
+	ret = block_truncate_page(inode->i_mapping, inode->i_size, ouichefs_file_get_block);
+	if (ret < 0)
+		goto out_brelse;
+
+	struct ouichefs_file_index_block *index = (struct ouichefs_file_index_block *)bh->b_data;
+
+	next_num_blocks = (inode->i_size + sb->s_blocksize - 1) >> sb->s_blocksize_bits;
+	for (size_t i = next_num_blocks; i < OUICHEFS_FILE_MAX_BLOCKS; ++i) {
+		uint32_t bno = le32_to_cpu(index->blocks[i]);
+
+		if (!bno)
+			continue;
+
+		put_block(sbi, bno);
+		--inode->i_blocks;
+
+		index->blocks[i] = cpu_to_le32(0);
+	}
+
+	mark_buffer_dirty(bh);
+	brelse(bh);
+
+	mark_inode_dirty(inode);
+
+	return 0;
+
+out_brelse:
+	brelse(bh);
+out:
+	return ret;
+}

--- a/file.c
+++ b/file.c
@@ -32,7 +32,7 @@ static int ouichefs_file_get_block(struct inode *inode, sector_t iblock,
 	int ret = 0, bno;
 
 	/* If block number exceeds filesize, fail */
-	if (iblock >= OUICHEFS_BLOCK_SIZE >> 2)
+	if (iblock >= OUICHEFS_FILE_MAX_BLOCKS)
 		return -EFBIG;
 
 	/* Read index block from disk */

--- a/file.c
+++ b/file.c
@@ -154,41 +154,8 @@ const struct address_space_operations ouichefs_aops = {
 	.write_end = ouichefs_write_end
 };
 
-static int ouichefs_open(struct inode *inode, struct file *file) {
-	bool wronly = (file->f_flags & O_WRONLY) != 0;
-	bool rdwr = (file->f_flags & O_RDWR) != 0;
-	bool trunc = (file->f_flags & O_TRUNC) != 0;
-
-	if ((wronly || rdwr) && trunc && (inode->i_size != 0)) {
-		struct super_block *sb = inode->i_sb;
-		struct ouichefs_sb_info *sbi = OUICHEFS_SB(sb);
-		struct ouichefs_inode_info *ci = OUICHEFS_INODE(inode);
-		struct ouichefs_file_index_block *index;
-		struct buffer_head *bh_index;
-		sector_t iblock;
-
-		/* Read index block from disk */
-		bh_index = sb_bread(sb, ci->index_block);
-		if (!bh_index)
-			return -EIO;
-		index = (struct ouichefs_file_index_block *)bh_index->b_data;
-
-		for (iblock = 0; index->blocks[iblock] != 0; iblock++) {
-			put_block(sbi, index->blocks[iblock]);
-			index->blocks[iblock] = 0;
-		}
-		inode->i_size = 0;
-		inode->i_blocks = 1;
-
-		brelse(bh_index);
-	}
-	
-	return 0;
-}
-
 const struct file_operations ouichefs_file_ops = {
 	.owner = THIS_MODULE,
-	.open = ouichefs_open,
 	.llseek = generic_file_llseek,
 	.read_iter = generic_file_read_iter,
 	.write_iter = generic_file_write_iter

--- a/inode.c
+++ b/inode.c
@@ -308,16 +308,13 @@ end:
 static int ouichefs_unlink(struct inode *dir, struct dentry *dentry)
 {
 	struct super_block *sb = dir->i_sb;
-	struct ouichefs_sb_info *sbi = OUICHEFS_SB(sb);
 	struct inode *inode = d_inode(dentry);
-	struct buffer_head *bh = NULL, *bh2 = NULL;
+	struct buffer_head *bh = NULL;
 	struct ouichefs_dir_block *dir_block = NULL;
-	struct ouichefs_file_index_block *file_block = NULL;
-	uint32_t ino, bno;
+	uint32_t ino;
 	int i, f_id = -1, nr_subs = 0;
 
 	ino = inode->i_ino;
-	bno = OUICHEFS_INODE(inode)->index_block;
 
 	/* Read parent directory index */
 	bh = sb_bread(sb, OUICHEFS_INODE(dir)->index_block);
@@ -342,64 +339,13 @@ static int ouichefs_unlink(struct inode *dir, struct dentry *dentry)
 	mark_buffer_dirty(bh);
 	brelse(bh);
 
+	inode_dec_link_count(inode);
+
 	/* Update inode stats */
 	dir->i_mtime = dir->i_atime = dir->i_ctime = current_time(dir);
 	if (S_ISDIR(inode->i_mode))
 		inode_dec_link_count(dir);
 	mark_inode_dirty(dir);
-
-	/*
-	 * Cleanup pointed blocks if unlinking a file. If we fail to read the
-	 * index block, cleanup inode anyway and lose this file's blocks
-	 * forever. If we fail to scrub a data block, don't fail (too late
-	 * anyway), just put the block and continue.
-	 */
-	bh = sb_bread(sb, bno);
-	if (!bh)
-		goto clean_inode;
-	file_block = (struct ouichefs_file_index_block *)bh->b_data;
-	if (S_ISDIR(inode->i_mode))
-		goto scrub;
-	for (i = 0; i < inode->i_blocks - 1; i++) {
-		char *block;
-
-		if (!file_block->blocks[i])
-			continue;
-
-		put_block(sbi, file_block->blocks[i]);
-		bh2 = sb_bread(sb, file_block->blocks[i]);
-		if (!bh2)
-			continue;
-		block = (char *)bh2->b_data;
-		memset(block, 0, OUICHEFS_BLOCK_SIZE);
-		mark_buffer_dirty(bh2);
-		brelse(bh2);
-	}
-
-scrub:
-	/* Scrub index block */
-	memset(file_block, 0, OUICHEFS_BLOCK_SIZE);
-	mark_buffer_dirty(bh);
-	brelse(bh);
-
-clean_inode:
-	/* Cleanup inode and mark dirty */
-	inode->i_blocks = 0;
-	OUICHEFS_INODE(inode)->index_block = 0;
-	inode->i_size = 0;
-	i_uid_write(inode, 0);
-	i_gid_write(inode, 0);
-	inode->i_mode = 0;
-	inode->i_ctime.tv_sec = inode->i_mtime.tv_sec = inode->i_atime.tv_sec =
-		0;
-	inode->i_ctime.tv_nsec = inode->i_mtime.tv_nsec = inode->i_atime.tv_nsec =
-		0;
-	inode_dec_link_count(inode);
-	mark_inode_dirty(inode);
-
-	/* Free inode and index block from bitmap */
-	put_block(sbi, bno);
-	put_inode(sbi, ino);
 
 	return 0;
 }
@@ -536,6 +482,8 @@ static int ouichefs_rmdir(struct inode *dir, struct dentry *dentry)
 		return -ENOTEMPTY;
 	}
 	brelse(bh);
+
+	inode_dec_link_count(inode);
 
 	/* Remove directory with unlink */
 	return ouichefs_unlink(dir, dentry);

--- a/inode.c
+++ b/inode.c
@@ -489,6 +489,32 @@ static int ouichefs_rmdir(struct inode *dir, struct dentry *dentry)
 	return ouichefs_unlink(dir, dentry);
 }
 
+static int ouichefs_setattr(struct mnt_idmap *idmap, struct dentry *dentry, struct iattr *iattr)
+{
+	int ret;
+	struct inode *inode = d_inode(dentry);
+
+	ret = setattr_prepare(&nop_mnt_idmap, dentry, iattr);
+	if (ret < 0)
+		return ret;
+
+	if (iattr->ia_valid & ATTR_SIZE) {
+		ret = inode_newsize_ok(inode, iattr->ia_size);
+		if (ret < 0)
+			return ret;
+
+		truncate_setsize(inode, iattr->ia_size);
+		if (ouichefs_truncate(inode) < 0)
+			pr_err("%s:%d: truncate failed\n", __func__, __LINE__);
+	}
+
+	/* Do simple metadata updates (this excludes setting the size) */
+	setattr_copy(&nop_mnt_idmap, inode, iattr);
+	mark_inode_dirty(inode);
+
+	return 0;
+}
+
 static const struct inode_operations ouichefs_inode_ops = {
 	.lookup = ouichefs_lookup,
 	.create = ouichefs_create,
@@ -496,4 +522,5 @@ static const struct inode_operations ouichefs_inode_ops = {
 	.mkdir = ouichefs_mkdir,
 	.rmdir = ouichefs_rmdir,
 	.rename = ouichefs_rename,
+	.setattr = ouichefs_setattr,
 };

--- a/ouichefs.h
+++ b/ouichefs.h
@@ -14,7 +14,8 @@
 #define OUICHEFS_SB_BLOCK_NR 0
 
 #define OUICHEFS_BLOCK_SIZE (1 << 12) /* 4 KiB */
-#define OUICHEFS_MAX_FILESIZE (1 << 22) /* 4 MiB */
+#define OUICHEFS_FILE_MAX_BLOCKS (OUICHEFS_BLOCK_SIZE >> 2)
+#define OUICHEFS_MAX_FILESIZE (OUICHEFS_FILE_MAX_BLOCKS * OUICHEFS_BLOCK_SIZE) /* 4 MiB */
 #define OUICHEFS_FILENAME_LEN 28
 #define OUICHEFS_MAX_SUBFILES 128
 
@@ -78,7 +79,7 @@ struct ouichefs_sb_info {
 };
 
 struct ouichefs_file_index_block {
-	uint32_t blocks[OUICHEFS_BLOCK_SIZE >> 2];
+	uint32_t blocks[OUICHEFS_FILE_MAX_BLOCKS];
 };
 
 struct ouichefs_dir_block {

--- a/ouichefs.h
+++ b/ouichefs.h
@@ -101,6 +101,7 @@ struct inode *ouichefs_iget(struct super_block *sb, unsigned long ino);
 extern const struct file_operations ouichefs_file_ops;
 extern const struct file_operations ouichefs_dir_ops;
 extern const struct address_space_operations ouichefs_aops;
+int ouichefs_truncate(struct inode *inode);
 
 /* Getters for superbock and inode */
 #define OUICHEFS_SB(sb) (sb->s_fs_info)

--- a/super.c
+++ b/super.c
@@ -123,7 +123,7 @@ static void ouichefs_evict_inode(struct inode *inode)
 		if (S_ISREG(inode->i_mode)) {
 			file_index = (struct ouichefs_file_index_block *)bh->b_data;
 
-			for (i = 0; i < inode->i_blocks - 1; ++i) {
+			for (i = 0; i < OUICHEFS_FILE_MAX_BLOCKS; ++i) {
 				if (!le32_to_cpu(file_index->blocks[i]))
 					continue;
 

--- a/super.c
+++ b/super.c
@@ -14,6 +14,7 @@
 #include <linux/statfs.h>
 
 #include "ouichefs.h"
+#include "bitmap.h"
 
 static struct kmem_cache *ouichefs_inode_cache;
 
@@ -93,6 +94,65 @@ static int ouichefs_write_inode(struct inode *inode,
 	brelse(bh);
 
 	return 0;
+}
+
+static void ouichefs_evict_inode(struct inode *inode)
+{
+	struct super_block *sb = inode->i_sb;
+	struct ouichefs_sb_info *sbi = OUICHEFS_SB(sb);
+	struct ouichefs_inode_info *inode_info = OUICHEFS_INODE(inode);
+	struct buffer_head *bh;
+	struct ouichefs_file_index_block *file_index;
+	uint32_t ino = inode->i_ino;
+	uint32_t i;
+
+	truncate_inode_pages_final(&inode->i_data);
+
+	/*
+	 * Cleanup pointed blocks if file/directory is not linked anymore.
+	 * If we fail to read the index block, cleanup inode anyway and
+	 * lose this file/directory's blocks forever.
+	 */
+	if (!inode->i_nlink && inode_info->index_block) {
+		bh = sb_bread(sb, inode_info->index_block);
+		if (!bh) {
+			pr_warn("failed to release index block\n");
+			goto invalidate;
+		}
+
+		if (S_ISREG(inode->i_mode)) {
+			file_index = (struct ouichefs_file_index_block *)bh->b_data;
+
+			for (i = 0; i < inode->i_blocks - 1; ++i) {
+				if (!le32_to_cpu(file_index->blocks[i]))
+					continue;
+
+				put_block(sbi, le32_to_cpu(file_index->blocks[i]));
+			}
+		}
+
+		/*
+		 * Make sure the buffer is not marked dirty anymore (and no writeback
+		 * is in progress), as we don't want it to be written back when it might
+		 * already be in use for something else (especially for the contents of a file)!
+		 */
+		lock_buffer(bh);
+		clear_buffer_dirty(bh);
+		unlock_buffer(bh);
+		brelse(bh);
+
+		put_block(sbi, inode_info->index_block);
+		inode_info->index_block = 0;
+	}
+
+invalidate:
+	invalidate_inode_buffers(inode);
+	clear_inode(inode);
+
+	if (!inode->i_nlink) {
+		/* Free inode from bitmap */
+		put_inode(sbi, ino);
+	}
 }
 
 static int sync_sb_info(struct super_block *sb, int wait)
@@ -227,6 +287,7 @@ static struct super_operations ouichefs_super_ops = {
 	.alloc_inode = ouichefs_alloc_inode,
 	.destroy_inode = ouichefs_destroy_inode,
 	.write_inode = ouichefs_write_inode,
+	.evict_inode = ouichefs_evict_inode,
 	.sync_fs = ouichefs_sync_fs,
 	.statfs = ouichefs_statfs,
 };


### PR DESCRIPTION
Support the truncation of files to arbitrary sizes (up to the maximum file size) by implementing `ouichefs_setattr()`. Before, the truncation would seemingly succeed, but associated blocks would not be freed.

When the file size decreases, excess blocks are freed. When the file size increases, the last bytes block in which the old end of file lied are zeroed, but no new blocks are allocated, which means that the index file may contain gaps/holes. Only when a real write to one of the new zeroed pages is performed, new blocks will be allocated for it, which matches the truncation implementation in most other file systems.

Based on #49.