### PR TITLE
mkfs: Add static target

### DIFF
--- a/mkfs/Makefile
+++ b/mkfs/Makefile
@@ -7,6 +7,9 @@ all: ${BIN}
 ${BIN}: mkfs-ouichefs.c
 	gcc -Wall -o $@ $<
 
+${BIN}-static: mkfs-ouichefs.c
+	gcc -Wall -static -o $@ $<
+
 img: ${BIN}
 	rm -rf ${IMG}
 	dd if=/dev/zero of=${IMG} bs=1M count=${IMGSIZE}


### PR DESCRIPTION
This helps with running mkfs.ouichefs inside of a virtual machine instead of having to explicitly run it on the host OS in the event that the guest OS and the host OS have different glibc versions.