### PR TITLE
Fix: Write back changes made to a file's index block when allocating new data blocks

### DIFF
--- a/file.c
+++ b/file.c
@@ -56,6 +56,7 @@ static int ouichefs_file_get_block(struct inode *inode, sector_t iblock,
 			goto brelse_index;
 		}
 		index->blocks[iblock] = bno;
+		mark_buffer_dirty(bh_index);
 	} else {
 		bno = index->blocks[iblock];
 	}
@@ -218,6 +219,7 @@ static int ouichefs_open(struct inode *inode, struct file *file) {
 		inode->i_size = 0;
 		inode->i_blocks = 1;
 
+		mark_buffer_dirty(bh_index);
 		brelse(bh_index);
 	}
 	


### PR DESCRIPTION
When translating the virtual sector number of a file to a physical device block, new data blocks may be allocated. If this is the case, the buffer of the index block was not properly set to dirty, leading to potential data loss.
The same happens when truncating a file, where each index block's reference is set to zero.
This PR adds the required lines.

LKP Project group winter term 24/25: Fynn Stebel, Leon Gentges, Lukas Joisten