### PR TITLE
Add fsync support

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -68,4 +68,5 @@ static int ouichefs_iterate(struct file *dir, struct dir_context *ctx)
 const struct file_operations ouichefs_dir_ops = {
 	.owner = THIS_MODULE,
 	.iterate_shared = ouichefs_iterate,
+	.fsync = generic_file_fsync,
 };

--- a/file.c
+++ b/file.c
@@ -229,5 +229,6 @@ const struct file_operations ouichefs_file_ops = {
 	.open = ouichefs_open,
 	.llseek = generic_file_llseek,
 	.read_iter = generic_file_read_iter,
-	.write_iter = generic_file_write_iter
+	.write_iter = generic_file_write_iter,
+	.fsync = generic_file_fsync,
 };


### PR DESCRIPTION
Some programs require fsync support to function properly. As an example `vim` fails to write files without it.
This also addresses #28.