### PR TITLE
Fix missing loop comparision in ouichefs_rename

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -478,7 +478,7 @@ static int ouichefs_rename(struct mnt_idmap *idmap, struct inode *old_dir,
 		return -EIO;
 	dir_block = (struct ouichefs_dir_block *)bh_old->b_data;
 	/* Search for inode in old directory and number of subfiles */
-	for (i = 0; OUICHEFS_MAX_SUBFILES; i++) {
+	for (i = 0; i < OUICHEFS_MAX_SUBFILES; i++) {
 		if (le32_to_cpu(dir_block->files[i].inode) == src->i_ino)
 			f_id = i;
 		else if (dir_block->files[i].inode == 0)


### PR DESCRIPTION
In ouichefs_rename the loop iterating over the directory block of the parent inode always evaluates a constant `OUICHEFS_MAX_SUBFILES` instead of a comparison with the variable that is iterated over. This can result in this loop performing out-of-bound reads.

This pull requests simply adds the comparison and prevents this out-of-bounds access.