### PR TITLE
properly truncate file in open(2)

### DIFF
--- a/file.c
+++ b/file.c
@@ -213,7 +213,9 @@ static int ouichefs_open(struct inode *inode, struct file *file)
 			return -EIO;
 		index = (struct ouichefs_file_index_block *)bh_index->b_data;
 
-		for (iblock = 0; index->blocks[iblock] != 0; iblock++) {
+		for (iblock = 0; iblock < inode->i_blocks - 1; iblock++) {
+			if (!index->blocks[iblock])
+				continue;
 			put_block(sbi, le32_to_cpu(index->blocks[iblock]));
 			index->blocks[iblock] = 0;
 		}


### PR DESCRIPTION
The code that supports `O_TRUNC` for `open(2)` stops iterating over a
file's data blocks as soon as the first zero entry in the index is encountered.
If a file has data blocks after such a "hole", they won't be cleared.
Thus, e.g. the following command sequence yields a wrong result:

```sh
$ echo old data | dd of=file bs=4k seek=1
$ echo new data >file  # "old data" block not cleared
$ truncate -s 5k  # increase file size to encompass the block
$ cat file  # expect "new data" plus many NUL bytes
new data
old data
```

---
(Group 7)