### PR TITLE
fix: missing macro parentheses in `OUICHEFS_SB`

### DIFF
--- a/ouichefs.h
+++ b/ouichefs.h
@@ -101,8 +101,8 @@ extern const struct file_operations ouichefs_file_ops;
 extern const struct file_operations ouichefs_dir_ops;
 extern const struct address_space_operations ouichefs_aops;
 
-/* Getters for superbock and inode */
-#define OUICHEFS_SB(sb) (sb->s_fs_info)
+/* Getters for superblock and inode */
+#define OUICHEFS_SB(sb) ((sb)->s_fs_info)
 #define OUICHEFS_INODE(inode) \
 	(container_of(inode, struct ouichefs_inode_info, vfs_inode))
 


### PR DESCRIPTION
For macro `OUICHEFS_SB`, `sb` doesn't wrap up by parentheses, which may cause error when complex expressions appears. For example:

```c
#define OUICHEFS_SB(sb) (sb->s_fs_info)

struct sb_struct {
    int s_fs_info;
};

int main() {
    struct sb_struct arr[2] = {{10}, {20}};
    int idx = 0;

    int x = OUICHEFS_SB(arr + idx);  // Works as expected

    int y = OUICHEFS_SB(idx ? &arr[1] : &arr[0]);
    //   expands to:
    //   (idx ? &arr[1] : &arr[0]->s_fs_info)   <-- WRONG
    // Because '->' binds tighter than '? :', only arr[0] gets '->'
}
```

Also, fixed the typo in the comment. (superbock -> superblock)

By Group 5