### PR TITLE
Synchronize bitmap accesses

### DIFF
--- a/bitmap.h
+++ b/bitmap.h
@@ -39,12 +39,15 @@ static inline uint32_t get_free_inode(struct ouichefs_sb_info *sbi)
 {
 	uint32_t ret;
 
+	mutex_lock(&sbi->inode_bitmap_lock);
+
 	ret = get_first_free_bit(sbi->ifree_bitmap, sbi->nr_inodes);
 	if (ret) {
 		sbi->nr_free_inodes--;
 		pr_debug("%s:%d: allocated inode %u\n", __func__, __LINE__,
 			 ret);
 	}
+	mutex_unlock(&sbi->inode_bitmap_lock);
 	return ret;
 }
 
@@ -56,12 +59,15 @@ static inline uint32_t get_free_block(struct ouichefs_sb_info *sbi)
 {
 	uint32_t ret;
 
+	mutex_lock(&sbi->block_bitmap_lock);
+
 	ret = get_first_free_bit(sbi->bfree_bitmap, sbi->nr_blocks);
 	if (ret) {
 		sbi->nr_free_blocks--;
 		pr_debug("%s:%d: allocated block %u\n", __func__, __LINE__,
 			 ret);
 	}
+	mutex_unlock(&sbi->block_bitmap_lock);
 	return ret;
 }
 
@@ -85,11 +91,14 @@ static inline int put_free_bit(unsigned long *freemap, unsigned long size,
  */
 static inline void put_inode(struct ouichefs_sb_info *sbi, uint32_t ino)
 {
+	mutex_lock(&sbi->inode_bitmap_lock);
 	if (put_free_bit(sbi->ifree_bitmap, sbi->nr_inodes, ino))
-		return;
+		goto out;
 
 	sbi->nr_free_inodes++;
 	pr_debug("%s:%d: freed inode %u\n", __func__, __LINE__, ino);
+	out:
+	mutex_unlock(&sbi->inode_bitmap_lock);
 }
 
 /*
@@ -97,11 +106,14 @@ static inline void put_inode(struct ouichefs_sb_info *sbi, uint32_t ino)
  */
 static inline void put_block(struct ouichefs_sb_info *sbi, uint32_t bno)
 {
+	mutex_lock(&sbi->block_bitmap_lock);
 	if (put_free_bit(sbi->bfree_bitmap, sbi->nr_blocks, bno))
-		return;
+		goto out;
 
 	sbi->nr_free_blocks++;
 	pr_debug("%s:%d: freed block %u\n", __func__, __LINE__, bno);
+	out:
+	mutex_unlock(&sbi->block_bitmap_lock);
 }
 
 static inline void copy_bitmap_from_le64(unsigned long *dst, __le64 *src)

--- a/ouichefs.h
+++ b/ouichefs.h
@@ -76,6 +76,9 @@ struct ouichefs_sb_info {
 
 	unsigned long *ifree_bitmap; /* In-memory free inodes bitmap */
 	unsigned long *bfree_bitmap; /* In-memory free blocks bitmap */
+
+	struct mutex inode_bitmap_lock; /* Mutex for inode bitmap */
+	struct mutex block_bitmap_lock; /* Mutex for block bitmap */
 };
 
 struct ouichefs_file_index_block {

--- a/super.c
+++ b/super.c
@@ -333,6 +333,8 @@ int ouichefs_fill_super(struct super_block *sb, void *data, int silent)
 	sbi->nr_free_inodes = le32_to_cpu(csb->nr_free_inodes);
 	sbi->nr_free_blocks = le32_to_cpu(csb->nr_free_blocks);
 	sb->s_fs_info = sbi;
+	mutex_init(&sbi->inode_bitmap_lock);
+	mutex_init(&sbi->block_bitmap_lock);
 
 	brelse(bh);
 


### PR DESCRIPTION
There is currently no synchronization mechanism on the block/inode bitmaps that isolates bitmap accesses for different files. As a result, the same blocks can be allocated for different files when multiple processes concurrently access the free blocks bitmap.

The following bash script can be used to demonstrate the bug:

```
#!/usr/bin/env bash

if [[ $# -ne 1 ]]; then
    echo "Usage: $0 N"
    exit 1
fi

N=$1

for ((i=0; i<N; i++)); do
    dd if=/dev/urandom of="file$((2*i))"   bs=4096 count=1024 conv=fsync > /dev/null 2>&1 &
    dd if=/dev/zero    of="file$((2*i+1))" bs=4096 count=1024 conv=fsync > /dev/null 2>&1 &
    wait
done

sync
echo 3 > /proc/sys/vm/drop_caches

for ((i=0; i<N; i++)); do
    file="file$((2*i+1))"

    if ! cmp -n $((4096 * 1024)) -s "$file" /dev/zero; then
        echo "file$((2*i+1)) is corrupted!"
    fi
done
```
It prints any corrupted files at the end and in this form needs to be run as root in order for `echo 3 > /proc/sys/vm/drop_caches` to work.

The main problem is that `get_first_free_bit` first searches for the first free bit and then clears it, but since this happens non-atomically nor in mutual exclusion, there is a race condition on that bit. The suggested fix uses per-superblock mutexes for the block and inode bitmaps on each bitmap access.

This bug has been found by Group 14 from the '26 LKP course at RWTH Aachen.