### PR TITLE
Fix bh_new leak on rename ENOENT path

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -385,7 +385,10 @@ static int ouichefs_rename(struct mnt_idmap *idmap, struct inode *old_dir,
 	}
 	/* if old_dir == new_dir, just rename entry */
 	if (old_dir == new_dir) {
-		if (f_pos < 0) return -ENOENT;
+		if (f_pos < 0) {
+			ret = -ENOENT;
+			goto relse_new;
+		}
 		strscpy(dir_block->files[f_pos].filename,
 			new_dentry->d_name.name, OUICHEFS_FILENAME_LEN);
 		mark_buffer_dirty(bh_new);


### PR DESCRIPTION
Fix a buffer head leak in `ouichefs_rename` by using the existing cleanup path when the rename operation fails with `-ENOENT`.